### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0
+FROM mcr.microsoft.com/dotnet/sdk:9.0
 WORKDIR /build
 
 RUN git clone --recursive https://github.com/space-wizards/SS14.Watchdog


### PR DESCRIPTION
bump dotnet version based on the error code when the docker container starts up

```
You must install or update .NET to run this application.

App: /app/instances/example/bin/Robust.Server
Architecture: x64
Framework: 'Microsoft.NETCore.App', version '9.0.0' (x64)
.NET location: /usr/share/dotnet

The following frameworks were found:
  8.0.11 at [/usr/share/dotnet/shared/Microsoft.NETCore.App]

Learn more:
https://aka.ms/dotnet/app-launch-failed
```